### PR TITLE
fix: always use `https` with LNURL, as per spec

### DIFF
--- a/lnurl/models.py
+++ b/lnurl/models.py
@@ -23,9 +23,9 @@ class ParsedUrl:
 
 
 class Lnurl:
-    def __init__(self, lnurl: str, *, force_https: bool = True) -> None:
+    def __init__(self, lnurl: str) -> None:
         self.bech32 = lnurl
-        self.url = ParsedUrl(decode(lnurl, force_https=force_https))
+        self.url = ParsedUrl(decode(lnurl))
 
     def __repr__(self) -> str:
         return f'<Lnurl [{self.bech32}]>'

--- a/lnurl/utils.py
+++ b/lnurl/utils.py
@@ -6,17 +6,17 @@ from urllib.parse import urlparse
 from .exceptions import InvalidLnurl, InvalidScheme, InvalidUrl
 
 
-def validate_url(url: str, force_https: bool = True) -> None:
+def validate_url(url: str) -> None:
     try:
         parsed = urlparse(url)
     except ValueError:  # pragma: nocover
         raise InvalidUrl
 
-    if force_https and parsed.scheme != 'https':
+    if parsed.scheme != 'https':
         raise InvalidScheme
 
 
-def decode(lnurl: str, *, force_https: bool = True) -> str:
+def decode(lnurl: str) -> str:
     lnurl = lnurl.replace('lightning:', '') if lnurl.startswith('lightning:') else lnurl
     hrp, data = bech32_decode(lnurl)
 
@@ -28,12 +28,12 @@ def decode(lnurl: str, *, force_https: bool = True) -> str:
     except UnicodeDecodeError:  # pragma: nocover
         raise InvalidLnurl
 
-    validate_url(url, force_https)
+    validate_url(url)
     return url
 
 
-def encode(url: str, *, force_https: bool = True) -> str:
-    validate_url(url, force_https)
+def encode(url: str) -> str:
+    validate_url(url)
 
     try:
         lnurl = bech32_encode('lnurl', convertbits(url.encode('utf-8'), 8, 5, True))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,9 +22,6 @@ class TestUtils:
     def test_encode(self):
         assert encode(self.lnurl[0]) == self.lnurl[1]
 
-        # https is enforced by default...
+        # https is enforced by default
         with pytest.raises(InvalidScheme):
             encode('http://lndhub.io/')
-
-        # ...but it can be ignored
-        encode('http://lndhub.io/', force_https=False)


### PR DESCRIPTION
The [LNURL spec](https://github.com/btcontract/lnurl-rfc/blob/master/spec.md) explicitly says that LNURL is for https URLs only:

> `LNURL` is a bech32-encoded HTTPS query string...

The package should not allow http URLs.